### PR TITLE
KNIG-44-Make-project-work-with-Postgres-database

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,8 @@
             <version>${mapstruct.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>runtime</scope>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java/com/knightcharacter/app/gateway/privatedb/representation/Bonus.java
+++ b/src/main/java/com/knightcharacter/app/gateway/privatedb/representation/Bonus.java
@@ -15,7 +15,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.GenericGenerator;
 
 @Entity
@@ -29,7 +28,6 @@ public class Bonus {
     @Id
     @GeneratedValue(generator = "uuid")
     @GenericGenerator(name = "uuid", strategy = "org.hibernate.id.UUIDGenerator")
-    @ColumnDefault("random_uuid()")
     @Column(name = "id")
     private String id;
 

--- a/src/main/java/com/knightcharacter/app/gateway/privatedb/representation/Character.java
+++ b/src/main/java/com/knightcharacter/app/gateway/privatedb/representation/Character.java
@@ -11,7 +11,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.GenericGenerator;
 
 @Entity
@@ -25,7 +24,6 @@ public class Character {
     @Id
     @GeneratedValue(generator = "uuid")
     @GenericGenerator(name = "uuid", strategy = "org.hibernate.id.UUIDGenerator")
-    @ColumnDefault("random_uuid()")
     @Column(name = "id")
     private String id;
 

--- a/src/main/java/com/knightcharacter/app/gateway/privatedb/representation/Item.java
+++ b/src/main/java/com/knightcharacter/app/gateway/privatedb/representation/Item.java
@@ -22,7 +22,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.GenericGenerator;
 
 @Entity
@@ -36,7 +35,6 @@ public abstract class Item {
     @Id
     @GeneratedValue(generator = "uuid")
     @GenericGenerator(name = "uuid", strategy = "org.hibernate.id.UUIDGenerator")
-    @ColumnDefault("random_uuid()")
     private String id;
 
     private String name;

--- a/src/main/java/com/knightcharacter/app/gateway/privatedb/representation/Skill.java
+++ b/src/main/java/com/knightcharacter/app/gateway/privatedb/representation/Skill.java
@@ -17,7 +17,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.GenericGenerator;
 
 @Entity
@@ -31,7 +30,6 @@ public class Skill {
     @Id
     @GeneratedValue(generator = "uuid")
     @GenericGenerator(name = "uuid", strategy = "org.hibernate.id.UUIDGenerator")
-    @ColumnDefault("random_uuid()")
     @Column(name = "id")
     private String id;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:postgresql://localhost/knight
+spring.datasource.username=${db.username}
+spring.datasource.password=${db.password}
+
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL10Dialect
+spring.jpa.properties.hibernate.default_schema=character
+
+spring.jpa.hibernate.ddl-auto=update

--- a/src/test/java/com/knightcharacter/app/integration/BonusResourceIntegrationTest.java
+++ b/src/test/java/com/knightcharacter/app/integration/BonusResourceIntegrationTest.java
@@ -36,7 +36,7 @@ import com.knightcharacter.app.gateway.privatedb.repository.BonusRepository;
 import com.knightcharacter.app.gateway.privatedb.representation.Bonus;
 import com.knightcharacter.app.rest.request.BonusRequestDto;
 
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,8 +58,8 @@ class BonusResourceIntegrationTest {
     @Autowired
     private BonusRepository bonusRepository;
 
-    @BeforeEach
-    void setUp() {
+    @AfterEach
+    void tearDown() {
         bonusRepository.deleteAll();
     }
 

--- a/src/test/java/com/knightcharacter/app/integration/CharacterResourceIntegrationTest.java
+++ b/src/test/java/com/knightcharacter/app/integration/CharacterResourceIntegrationTest.java
@@ -24,7 +24,7 @@ import com.knightcharacter.app.gateway.privatedb.repository.CharacterRepository;
 import com.knightcharacter.app.gateway.privatedb.representation.Character;
 import com.knightcharacter.app.rest.request.CharacterRequestDto;
 
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,8 +46,8 @@ public class CharacterResourceIntegrationTest {
     @Autowired
     private CharacterRepository characterRepository;
 
-    @BeforeEach
-    public void setUp() {
+    @AfterEach
+    public void tearDown() {
         characterRepository.deleteAll();
     }
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,9 @@
+spring.datasource.url=jdbc:postgresql://localhost/knight-test
+spring.datasource.username=${test.db.username}
+spring.datasource.password=${test.db.password}
+
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL10Dialect
+spring.jpa.properties.hibernate.default_schema=character
+
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.show-sql=true


### PR DESCRIPTION
1. added postgresql support to microservice
2. removed h2 support from microservice
3. removed redundant column defaults from entities because it is not necessary and not supported by postgresql
4. replaced all beforeEach methods in tests with afterEach to clean a db after tests
5. hid db passwords and usernames